### PR TITLE
sync: promote GitLab HEAD@658ee63 feat/onprem-cgw-interlinks

### DIFF
--- a/dx-visualizer/docs/VISUALIZATION.md
+++ b/dx-visualizer/docs/VISUALIZATION.md
@@ -68,6 +68,7 @@ Every node displays an icon, a friendly name, a subtitle, a resource ID, and key
 | Edge | Between | Data Shown |
 |---|---|---|
 | **Physical link** | Customer Gateway → Partner / Customer Device | (no label) — **user-drawn**; not auto-rendered |
+| **Customer Link** | Customer Gateway ↔ Customer Gateway, or Partner / Customer Device ↔ Partner / Customer Device | (no label, same as the physical link) — **user-drawn**; not auto-rendered. Joins two customer-owned devices of the *same* kind. Routes bottom→top between them, and is point-to-point like a peering (hovering highlights the pair, not both devices' full end-to-end paths). Because the cable is bidirectional, it hangs off the end-to-end path rather than extending it: clicking or hovering **any** node on either device's path covers the link and lights up the device at the far end, but stops there rather than pulling that device's own path in |
 | **DX Connection** | Partner / Customer Device → AWS Device | Connection name, connection ID, bandwidth, connection state |
 | **VIF** | AWS Device → DX Gateway or VGW | VIF type (Private/Transit/Public), VLAN ID, VIF ID, VIF state*, BGP status* |
 | **DX GW Association** | DX Gateway → TGW or VGW | Allowed prefix CIDRs, association state* |
@@ -78,6 +79,15 @@ Every node displays an icon, a friendly name, a subtitle, a resource ID, and key
 | **Recommended** | Any gap | Dashed green — suggested resiliency improvement |
 
 \* Only visible when **Live Status** toggle is ON (see [Live Status Layer](#6-live-status-layer))
+
+**Naming note** — the two customer-owned node kinds are easy to mix up, because the names in this table are not the subtitles printed on the cards:
+
+| This table calls it | The card's subtitle reads | Where it sits |
+|---|---|---|
+| Customer Gateway | **Customer Router** | Customer Site container |
+| Partner / Customer Device | **Customer Gateway** | DX Location container |
+
+Both can be linked to others of their own kind, and both offer the same top/bottom handles for it.
 
 All existing edges are solid purple bezier curves with animated flow dots. Recommended edges are dashed green.
 
@@ -148,7 +158,8 @@ The canvas supports a small set of in-place edits that persist in `localStorage`
 | **Remove added Customer Data Center** | Click the `×` button in a user-added zone's header. Only user-added zones expose this affordance — AWS-discovered sites cannot be removed. |
 | **Drag / resize added Customer Data Center** | Once the canvas is unlocked, drag the header to move it or use the corner handles to resize. User-added zones override layout-engine placement. |
 | **Draw Customer Gateway → Partner Device cable** | Drag from a Customer Gateway's right handle to a Partner / Customer Device's left handle. This edge is no longer auto-drawn — the user is responsible for modeling how their on-prem routers cable to the partner demarc. |
-| **Remove a cable** | Hover a Customer Gateway → Partner Device edge to reveal an `×` above the midpoint, or click the edge and press **Delete** / **Backspace**. Hidden edges render as dim dashed lines so you can still see where they used to be. |
+| **Draw a Customer Link** | Drag between any two Customer Gateways (an HA pair inside one data center, or two sites), or between any two Partner / Customer Devices (the customer's own kit across two DX locations). Neither AWS nor the DX APIs report customer-side cabling, so a resiliency reader otherwise cannot tell devices that back each other up from two single points of failure side by side. Both node kinds carry a handle on their top and bottom edge; any handle works as the start, because the edge is always re-anchored bottom→top with the upper device as the source, and drawing it again the other way round is a no-op rather than a second overlapping edge. Mixing the two kinds gives the cross-connect above, not a link. Like the cross-connect, the link is drawn unlabelled — hover the line itself for the point-to-point highlight. |
+| **Remove a cable** | Hover any user-drawn edge — a cross-connect or a Customer Link — to reveal an `×` above the midpoint, or click the edge and press **Delete** / **Backspace**. Only user-drawn edges expose either affordance; AWS-reported edges cannot be removed. Hidden edges render as dim dashed lines so you can still see where they used to be. |
 
 **Reset behavior**: Switching mock scenarios or refreshing live AWS topology wipes all user edits — node IDs change across fetches, so any persisted customizations would render as stray references.
 

--- a/dx-visualizer/src/components/FlowCanvas.tsx
+++ b/dx-visualizer/src/components/FlowCanvas.tsx
@@ -16,6 +16,7 @@ import {
 } from '@xyflow/react';
 import { useTopologyStore } from '../store/topology-store';
 import { computeDropSnap } from '../utils/drop-snap';
+import { planUserEdge, isUserDrawnPair, type ConnectEndpoint } from '../utils/user-edges';
 import { CustomerSiteNode } from './nodes/CustomerSiteNode';
 import { OnPremiseNode } from './nodes/OnPremiseNode';
 import { CgwNode } from './nodes/CgwNode';
@@ -485,21 +486,28 @@ export function FlowCanvas() {
         : [...currentNodes, ...userOnPremises];
       const nodeMap = new Map(allNodes.map((n) => [n.id, n]));
 
-      const srcCat = (nodeMap.get(connection.source)?.data as Record<string, unknown>)?.category;
-      const tgtCat = (nodeMap.get(connection.target)?.data as Record<string, unknown>)?.category;
-      if (srcCat !== 'onPremise' || tgtCat !== 'dxPartnerDevice') return;
+      // Absolute Y comes from the live ReactFlow node rather than `nodeMap`, so a
+      // router the user has already dragged is measured where it now sits — that
+      // position decides which end of a customer link is the source.
+      const endpoint = (nodeId: string): ConnectEndpoint | undefined => {
+        const node = nodeMap.get(nodeId);
+        if (!node) return undefined;
+        const live = getNode(nodeId);
+        return {
+          id: nodeId,
+          category: node.data.category,
+          y: live ? getAbsolutePosition(live).y : node.position.y,
+        };
+      };
 
-      const edgeId = `user-${connection.source}-${connection.target}`;
-      addUserEdge({
-        id: edgeId,
-        source: connection.source,
-        target: connection.target,
-        sourceHandle: connection.sourceHandle ?? undefined,
-        targetHandle: connection.targetHandle ?? undefined,
-        type: 'customEdge',
-      });
+      const planned = planUserEdge(
+        endpoint(connection.source),
+        endpoint(connection.target),
+        { sourceHandle: connection.sourceHandle, targetHandle: connection.targetHandle },
+      );
+      if (planned) addUserEdge(planned.edge);
     },
-    [isLocked, isSimulating, viewMode, currentNodes, recommendedNodes, recommendedCurrentNodes, userOnPremises, addUserEdge],
+    [isLocked, isSimulating, viewMode, currentNodes, recommendedNodes, recommendedCurrentNodes, userOnPremises, addUserEdge, getNode, getAbsolutePosition],
   );
 
   const nodes = useMemo(() => {
@@ -829,7 +837,10 @@ export function FlowCanvas() {
     return () => document.removeEventListener('mousedown', handler);
   }, [clearTextSelection]);
 
-  // Delete/Backspace removes the selected edge (only onPremise → dxPartnerDevice)
+  // Delete/Backspace removes the selected edge, for the same user-drawn edges that
+  // carry the × affordance. Both the edge list and the node map have to include
+  // the user's own additions: every deletable edge is in `userEdges` by
+  // definition, and a customer link can land on a router the user added.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (isLocked || isSimulating || !selectedEdgeId) return;
@@ -839,26 +850,26 @@ export function FlowCanvas() {
       if (tag === 'INPUT' || tag === 'TEXTAREA') return;
 
       const allNodes = viewMode === 'recommended' && recommendedCurrentNodes.length > 0
-        ? [...recommendedCurrentNodes, ...recommendedNodes]
-        : [...currentNodes];
+        ? [...recommendedCurrentNodes, ...recommendedNodes, ...userOnPremises]
+        : [...currentNodes, ...userOnPremises];
       const nodeMap = new Map(allNodes.map((n) => [n.id, n]));
 
       const allEdges = viewMode === 'recommended'
-        ? [...currentEdges, ...recommendedEdges]
-        : [...currentEdges];
+        ? [...currentEdges, ...recommendedEdges, ...userEdges]
+        : [...currentEdges, ...userEdges];
       const edge = allEdges.find((ed) => ed.id === selectedEdgeId);
       if (!edge) return;
 
-      const srcCat = (nodeMap.get(edge.source)?.data as Record<string, unknown>)?.category;
-      const tgtCat = (nodeMap.get(edge.target)?.data as Record<string, unknown>)?.category;
-      if (srcCat === 'onPremise' && tgtCat === 'dxPartnerDevice') {
+      const srcCat = (nodeMap.get(edge.source)?.data as Record<string, unknown>)?.category as string | undefined;
+      const tgtCat = (nodeMap.get(edge.target)?.data as Record<string, unknown>)?.category as string | undefined;
+      if (isUserDrawnPair(srcCat, tgtCat)) {
         hideEdge(edge.id);
         setSelectedEdgeId(null);
       }
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [isLocked, isSimulating, selectedEdgeId, viewMode, currentNodes, currentEdges, recommendedNodes, recommendedEdges, recommendedCurrentNodes, hideEdge]);
+  }, [isLocked, isSimulating, selectedEdgeId, viewMode, currentNodes, currentEdges, recommendedNodes, recommendedEdges, recommendedCurrentNodes, userOnPremises, userEdges, hideEdge]);
 
   return (
     <div className="relative w-full h-full" style={{

--- a/dx-visualizer/src/components/nodes/BaseNode.tsx
+++ b/dx-visualizer/src/components/nodes/BaseNode.tsx
@@ -29,6 +29,14 @@ interface BaseNodeProps {
   // that require a named source handle on the left.
   extraLeftHandles?: { id: string; type: 'source' | 'target'; background?: string }[];
   extraRightHandles?: { id: string; type: 'source' | 'target'; background?: string }[];
+  // Named handles on the card's top/bottom edge, for edges that route vertically
+  // between two nodes in the SAME column. Rendered last, so ReactFlow still
+  // resolves an edge that names no handle to the default left/right pair —
+  // otherwise a vertical handle would capture unqualified edges and send them
+  // out of the top of the card. Anchored to the card rather than the node box so
+  // the dot sits on the visible border, not on the layout padding around it.
+  extraTopHandles?: { id: string; type: 'source' | 'target'; background?: string }[];
+  extraBottomHandles?: { id: string; type: 'source' | 'target'; background?: string }[];
   children?: React.ReactNode;
   nodeId?: string;
   // Rendered absolutely-positioned at the visible node's top-right corner.
@@ -48,6 +56,8 @@ export const BaseNode = memo(function BaseNode({
   targetHandleIds,
   extraLeftHandles,
   extraRightHandles,
+  extraTopHandles,
+  extraBottomHandles,
   children,
   nodeId,
   topRightOverlay,
@@ -227,6 +237,24 @@ export const BaseNode = memo(function BaseNode({
             id={h.id}
             type={h.type}
             position={Position.Right}
+            style={{ background: h.background ?? effectiveBorder, width: 6, height: 6 }}
+          />
+        ))}
+        {extraTopHandles?.map((h) => (
+          <Handle
+            key={h.id}
+            id={h.id}
+            type={h.type}
+            position={Position.Top}
+            style={{ background: h.background ?? effectiveBorder, width: 6, height: 6 }}
+          />
+        ))}
+        {extraBottomHandles?.map((h) => (
+          <Handle
+            key={h.id}
+            id={h.id}
+            type={h.type}
+            position={Position.Bottom}
             style={{ background: h.background ?? effectiveBorder, width: 6, height: 6 }}
           />
         ))}

--- a/dx-visualizer/src/components/nodes/DxPartnerDeviceNode.tsx
+++ b/dx-visualizer/src/components/nodes/DxPartnerDeviceNode.tsx
@@ -19,6 +19,13 @@ export function DxPartnerDeviceNode({ id, data }: NodeProps) {
       accent={d.isInferred ? 'inferred' : 'default'}
       bgColor="#1e1033"
       badges={d.badges}
+      // Customer-link anchors, same as the on-prem routers. These cards share one
+      // column, so a link between two of them drops vertically rather than
+      // looping right→left around both. Both render after BaseNode's default
+      // left/right pair, so the unnamed DX Connection edge to the AWS device
+      // still resolves to the right-hand handle.
+      extraTopHandles={[{ id: 'top', type: 'target' }]}
+      extraBottomHandles={[{ id: 'bottom', type: 'source' }]}
     >
       {showLiveStatus && <LiveStatusDot state={state} />}
     </BaseNode>

--- a/dx-visualizer/src/components/nodes/OnPremiseNode.tsx
+++ b/dx-visualizer/src/components/nodes/OnPremiseNode.tsx
@@ -90,6 +90,12 @@ export function OnPremiseNode({ id, data }: NodeProps) {
       badges={d.badges}
       handles={{ source: true, target: true }}
       extraLeftHandles={[{ id: 'left-source', type: 'source' }]}
+      // Customer-link anchors. Routers all share one column, so a link between
+      // two of them drops vertically instead of looping right→left around both
+      // cards. `planUserEdge` pins every customer link to this pair, so the user
+      // can start the drag from any dot and still get the clean route.
+      extraTopHandles={[{ id: 'top', type: 'target' }]}
+      extraBottomHandles={[{ id: 'bottom', type: 'source' }]}
       topRightOverlay={overlay}
     >
       {d.resourceId && (

--- a/dx-visualizer/src/edges/CustomEdge.tsx
+++ b/dx-visualizer/src/edges/CustomEdge.tsx
@@ -6,6 +6,7 @@ import { PEERING_INTRA_OFFSET, PEERING_CROSS_CLEARANCE } from '../utils/constant
 import { parseBandwidthToBps, formatBps } from '../utils/shared';
 import { useTopologyStore } from '../store/topology-store';
 import { useRedact } from '../utils/redact';
+import { isUserDrawnPair } from '../utils/user-edges';
 
 function useNodeCategory(nodeId: string): string | undefined {
   return useTopologyStore((s) => {
@@ -70,7 +71,10 @@ export function CustomEdge({
   const isHiddenEdge = useTopologyStore((s) => s.hiddenEdgeIds.has(id));
   const sourceCat = useNodeCategory(source);
   const targetCat = useNodeCategory(target);
-  const isDeletableEdge = sourceCat === 'onPremise' && targetCat === 'dxPartnerDevice';
+  // Only user-drawn edges are deletable, and the connect rules decide which those
+  // are — so the × appears on exactly the edges the canvas can create and on
+  // nothing the AWS APIs reported.
+  const isDeletableEdge = isUserDrawnPair(sourceCat, targetCat);
   const hasHoverActive = hoveredNodeId != null;
   const isEdgeHighlighted = hasHoverActive && highlightedEdgeIds.has(id);
   // Don't fade deletable edges — their × affordance must stay readable/clickable.

--- a/dx-visualizer/src/store/__tests__/customer-link-highlight.test.ts
+++ b/dx-visualizer/src/store/__tests__/customer-link-highlight.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useTopologyStore } from '../topology-store';
+import type { DxEdge } from '../../types/topology';
+import { customerLinkId } from '../../utils/user-edges';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+/**
+ * Two redundant DX paths through one colo, each ending at its own AWS logical
+ * device but sharing a DX gateway — the shape in the screenshot that showed the
+ * bug:
+ *
+ *   router-1 → partnerUpper → awsdev-1 ─┐
+ *        (customer link, drawn by hand)  ├→ dxgw
+ *   router-2 → partnerLower → awsdev-2 ─┘
+ *
+ * The customer link joins the two partner devices. It is the only edge here the
+ * user drew; everything else came from the AWS APIs.
+ */
+const LINK_ID = customerLinkId('partnerUpper', 'partnerLower');
+
+const e = (source: string, target: string): DxEdge => ({ id: `e-${source}-${target}`, source, target });
+
+// Anchored upper→lower, exactly as `planUserEdge` builds it.
+const customerLink: DxEdge = {
+  id: LINK_ID,
+  source: 'partnerUpper',
+  target: 'partnerLower',
+  sourceHandle: 'bottom',
+  targetHandle: 'top',
+  data: { isPeering: true, isLateral: true },
+};
+
+const AWS_EDGES: DxEdge[] = [
+  e('router-1', 'partnerUpper'),
+  e('router-2', 'partnerLower'),
+  e('partnerUpper', 'awsdev-1'),
+  e('partnerLower', 'awsdev-2'),
+  e('awsdev-1', 'dxgw'),
+  e('awsdev-2', 'dxgw'),
+];
+
+function seed() {
+  useTopologyStore.setState({
+    viewMode: 'current',
+    currentEdges: AWS_EDGES,
+    recommendedEdges: [],
+    userEdges: [customerLink],
+    pinnedNodeId: null,
+    highlightedNodeIds: new Set(),
+    highlightedEdgeIds: new Set(),
+  });
+}
+
+function clickHighlight(nodeId: string) {
+  useTopologyStore.getState().setPinnedNode(nodeId);
+  const { highlightedNodeIds, highlightedEdgeIds } = useTopologyStore.getState();
+  useTopologyStore.getState().setPinnedNode(null);
+  return { nodes: highlightedNodeIds, edges: highlightedEdgeIds };
+}
+
+beforeEach(seed);
+
+describe('clicking a node highlights the customer link regardless of which end is upper', () => {
+  // The upper/lower split is a cosmetic routing choice, so nothing about the
+  // highlight may depend on it.
+  it.each([
+    ['the lower partner device', 'partnerLower'],
+    ['the upper partner device', 'partnerUpper'],
+    ['the AWS device behind the lower one', 'awsdev-2'],
+    ['the AWS device behind the upper one', 'awsdev-1'],
+    ['the router feeding the lower one', 'router-2'],
+    ['the router feeding the upper one', 'router-1'],
+    ['the shared DX gateway', 'dxgw'],
+  ])('covers it when clicking %s', (_label, nodeId) => {
+    expect(clickHighlight(nodeId).edges).toContain(LINK_ID);
+  });
+
+  it('highlights both ends of the link, so the redundant pair reads as related', () => {
+    const { nodes } = clickHighlight('awsdev-1');
+    expect(nodes).toContain('partnerUpper');
+    expect(nodes).toContain('partnerLower');
+  });
+});
+
+describe('a customer link does not leak the peer path into the highlight', () => {
+  it('stops at the peer instead of dragging its whole path along', () => {
+    // Clicking the upper AWS device must not pull in the LOWER path's own
+    // router or AWS device — the link says "these two back each other up", not
+    // "these are one path".
+    const { nodes } = clickHighlight('awsdev-1');
+    expect(nodes).toContain('router-1');
+    expect(nodes).not.toContain('router-2');
+    expect(nodes).not.toContain('awsdev-2');
+  });
+
+  it('leaves AWS-reported peerings on the directional traversal', () => {
+    // Scope marker, not an endorsement: VPC↔VPC / TGW↔TGW / Cloud WAN peerings
+    // are `isPeering` but NOT `isLateral`, so they are still walked as path
+    // steps and keep the same asymmetry. Flipping them would change what
+    // clicking a Core Network or a peered VPC covers, which is a separate call.
+    const vpcPeering: DxEdge = {
+      id: 'e-vpcpeer-1', source: 'vpc-a', target: 'vpc-b',
+      data: { isPeering: true },
+    };
+    useTopologyStore.setState({
+      currentEdges: [e('tgw-1', 'vpc-a'), vpcPeering],
+      userEdges: [],
+    });
+    // Reached from the accepter, the peering pulls the requester's whole upstream
+    // in — today's behaviour, unchanged by this fix.
+    expect(clickHighlight('vpc-b').nodes).toContain('tgw-1');
+  });
+
+  it('still covers the clicked node\'s own end-to-end path', () => {
+    const { nodes, edges } = clickHighlight('awsdev-1');
+    for (const id of ['router-1', 'partnerUpper', 'awsdev-1', 'dxgw']) {
+      expect(nodes, `${id} is on the clicked path`).toContain(id);
+    }
+    for (const id of ['e-router-1-partnerUpper', 'e-partnerUpper-awsdev-1', 'e-awsdev-1-dxgw']) {
+      expect(edges, `${id} is on the clicked path`).toContain(id);
+    }
+  });
+});

--- a/dx-visualizer/src/store/topology-store.ts
+++ b/dx-visualizer/src/store/topology-store.ts
@@ -7,6 +7,7 @@ import { WELCOME_MESSAGE, type MockScenario } from '../utils/shared';
 import { config } from '../utils/config';
 import { fetchUtilization } from '../api/cloudwatch-utilization';
 import { deserializeTopologyData, type SnapshotFile } from '../utils/snapshot';
+import { normalizeUserEdges } from '../utils/user-edges';
 
 // Metadata exposed to the UI when an imported snapshot is being viewed.
 // Banner / TopBar read this to render the "Viewing imported snapshot" affordances.
@@ -435,6 +436,9 @@ const savedChat = (() => {
 type AdjMaps = {
   incoming: Map<string, { edgeId: string; source: string }[]>;
   outgoing: Map<string, { edgeId: string; target: string }[]>;
+  // `isLateral` edges, keyed by BOTH endpoints. They are deliberately absent
+  // from incoming/outgoing: see computePath.
+  lateral: Map<string, { edgeId: string; peer: string }[]>;
 };
 const currentAdjCache = new WeakMap<DxEdge[], WeakMap<DxEdge[], AdjMaps>>();
 const recommendedAdjCache = new WeakMap<DxEdge[], WeakMap<DxEdge[], WeakMap<DxEdge[], AdjMaps>>>();
@@ -442,13 +446,26 @@ const recommendedAdjCache = new WeakMap<DxEdge[], WeakMap<DxEdge[], WeakMap<DxEd
 function buildAdjMaps(edges: DxEdge[]): AdjMaps {
   const incoming = new Map<string, { edgeId: string; source: string }[]>();
   const outgoing = new Map<string, { edgeId: string; target: string }[]>();
+  const lateral = new Map<string, { edgeId: string; peer: string }[]>();
+  const addLateral = (from: string, edgeId: string, peer: string) => {
+    if (!lateral.has(from)) lateral.set(from, []);
+    lateral.get(from)!.push({ edgeId, peer });
+  };
   for (const e of edges) {
+    if (e.data?.isLateral) {
+      // Recorded from both ends and kept out of the directed graph, so the
+      // traversal can never walk *through* it in whichever direction it was
+      // drawn.
+      addLateral(e.source, e.id, e.target);
+      addLateral(e.target, e.id, e.source);
+      continue;
+    }
     if (!incoming.has(e.target)) incoming.set(e.target, []);
     if (!outgoing.has(e.source)) outgoing.set(e.source, []);
     incoming.get(e.target)!.push({ edgeId: e.id, source: e.source });
     outgoing.get(e.source)!.push({ edgeId: e.id, target: e.target });
   }
-  return { incoming, outgoing };
+  return { incoming, outgoing, lateral };
 }
 
 function getAdjMaps(
@@ -498,7 +515,7 @@ function computePath(
   id: string,
   state: { viewMode: ViewMode; currentEdges: DxEdge[]; recommendedEdges: DxEdge[]; userEdges: DxEdge[] },
 ): { nodes: Set<string>; edges: Set<string> } {
-  const { incoming, outgoing } = getAdjMaps(state.viewMode, state.currentEdges, state.recommendedEdges, state.userEdges);
+  const { incoming, outgoing, lateral } = getAdjMaps(state.viewMode, state.currentEdges, state.recommendedEdges, state.userEdges);
   const nodes = new Set<string>([id]);
   const edges = new Set<string>();
   const upQueue: string[] = [id];
@@ -525,6 +542,26 @@ function computePath(
         nodes.add(target);
         downQueue.push(target);
       }
+    }
+  }
+  // Lateral cables hang off the finished path rather than extending it. A
+  // Customer Link is bidirectional kit-to-kit cabling whose drawn direction is
+  // only a routing choice, so walking it like a path step made the highlight
+  // depend on which end was the upper one: clicking the DX gateway caught the
+  // link (it sits upstream of the lower device) while clicking the AWS device
+  // behind the upper one missed it.
+  //
+  // Attaching it here instead covers it from either side. One hop only — the far
+  // device joins the highlight so the redundant pair reads as related, but its
+  // own upstream and downstream stay out, because the link means "these two back
+  // each other up", not "these two are one path". Iterating a snapshot keeps it
+  // to that one hop.
+  for (const n of [...nodes]) {
+    const sides = lateral.get(n);
+    if (!sides) continue;
+    for (const { edgeId, peer } of sides) {
+      edges.add(edgeId);
+      nodes.add(peer);
     }
   }
   return { nodes, edges };
@@ -1052,7 +1089,9 @@ export const useTopologyStore = create<TopologyStore>((set, get) => ({
   userEdges: (() => {
     try {
       const raw = localStorage.getItem(USER_EDGES_KEY);
-      if (raw) return JSON.parse(raw) as DxEdge[];
+      // Normalized on the way in: a link drawn by an older build comes back
+      // without the `data` flags that build had not defined yet.
+      if (raw) return normalizeUserEdges(JSON.parse(raw) as DxEdge[]);
     } catch { /* ignore */ }
     return [];
   })(),
@@ -1509,7 +1548,7 @@ export const useTopologyStore = create<TopologyStore>((set, get) => ({
       expandedUnattachedZone: view.expandedUnattachedZone,
       expandedHiddenAssocZone: view.expandedHiddenAssocZone,
 
-      userEdges: cust.userEdges ?? [],
+      userEdges: normalizeUserEdges(cust.userEdges ?? []),
       hiddenEdgeIds,
       edgeReconnectOverrides,
       userCustomerSites: cust.userCustomerSites ?? [],

--- a/dx-visualizer/src/types/topology.ts
+++ b/dx-visualizer/src/types/topology.ts
@@ -235,6 +235,13 @@ export type DxEdge = Edge & {
     // highlights only the single edge + its two endpoints, not a full E2E BFS
     // path — a peering is a point-to-point relationship, not an upstream path.
     isPeering?: boolean;
+    // Excludes the edge from the directed path graph: it is a cable between two
+    // devices that back each other up, not a step along anyone's path. The
+    // end-to-end traversal attaches it (and the device at the far end) to a path
+    // it touches, then stops, so the highlight cannot depend on which end the
+    // edge happens to be drawn from. Set on user-drawn Customer Links, whose
+    // direction is a purely cosmetic routing choice.
+    isLateral?: boolean;
     // For VPC↔VPC peering edges: whether both endpoints sit in the SAME region
     // ('intra') or different regions ('cross'). Drives lane routing — intra
     // peerings stay inside their region box with a fixed lane offset; cross

--- a/dx-visualizer/src/utils/__tests__/user-edges.test.ts
+++ b/dx-visualizer/src/utils/__tests__/user-edges.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planUserEdge,
+  isUserDrawnPair,
+  normalizeUserEdges,
+  customerLinkId,
+  type ConnectEndpoint,
+} from '../user-edges';
+
+const router = (id: string, y: number): ConnectEndpoint => ({ id, category: 'onPremise', y });
+// `dxPartnerDevice` is the card the UI labels "Customer Gateway" — the customer's
+// own device in the DX location.
+const partner = (id: string, y = 0): ConnectEndpoint => ({ id, category: 'dxPartnerDevice', y });
+
+describe('planUserEdge — cross-connect (router → partner device)', () => {
+  it('keeps the handles the user grabbed', () => {
+    const planned = planUserEdge(router('onprem-EqDC2', 100), partner('partner-dxcon-a'), {
+      sourceHandle: 'left-source',
+      targetHandle: null,
+    });
+    expect(planned).not.toBeNull();
+    expect(planned!.kind).toBe('crossConnect');
+    expect(planned!.edge).toMatchObject({
+      id: 'user-onprem-EqDC2-partner-dxcon-a',
+      source: 'onprem-EqDC2',
+      target: 'partner-dxcon-a',
+      sourceHandle: 'left-source',
+      targetHandle: undefined,
+      type: 'customEdge',
+    });
+  });
+
+  it('is not a peering edge, so it keeps full end-to-end hover', () => {
+    const planned = planUserEdge(router('onprem-EqDC2', 0), partner('partner-dxcon-a'));
+    expect(planned!.edge.data?.isPeering).toBeUndefined();
+  });
+});
+
+describe('planUserEdge — customer link (router ↔ router)', () => {
+  it('connects two on-prem routers', () => {
+    const planned = planUserEdge(router('onprem-EqDC2', 100), router('onprem-EqSE2', 400));
+    expect(planned).not.toBeNull();
+    expect(planned!.kind).toBe('customerLink');
+    expect(planned!.edge.type).toBe('customEdge');
+  });
+
+  it('anchors the upper router as the source and routes bottom → top', () => {
+    const planned = planUserEdge(router('onprem-EqDC2', 100), router('onprem-EqSE2', 400));
+    expect(planned!.edge).toMatchObject({
+      source: 'onprem-EqDC2',
+      target: 'onprem-EqSE2',
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+    });
+  });
+
+  it('re-orients when the user drags upward, so the line still drops down', () => {
+    // Dragged from the LOWER router to the upper one.
+    const planned = planUserEdge(router('onprem-EqSE2', 400), router('onprem-EqDC2', 100));
+    expect(planned!.edge).toMatchObject({
+      source: 'onprem-EqDC2',
+      target: 'onprem-EqSE2',
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+    });
+  });
+
+  it('overrides whichever handles the user grabbed', () => {
+    const planned = planUserEdge(router('a', 0), router('b', 50), {
+      sourceHandle: 'left-source',
+      targetHandle: 'top',
+    });
+    expect(planned!.edge.sourceHandle).toBe('bottom');
+    expect(planned!.edge.targetHandle).toBe('top');
+  });
+
+  it('breaks an exact y tie on id so the direction is stable either way round', () => {
+    const forward = planUserEdge(router('onprem-aaa', 200), router('onprem-bbb', 200));
+    const reverse = planUserEdge(router('onprem-bbb', 200), router('onprem-aaa', 200));
+    expect(forward!.edge.source).toBe('onprem-aaa');
+    expect(reverse!.edge.source).toBe('onprem-aaa');
+  });
+
+  it('is a peering edge, so hovering highlights the pair not both full paths', () => {
+    const planned = planUserEdge(router('a', 0), router('b', 50));
+    expect(planned!.edge.data?.isPeering).toBe(true);
+  });
+
+  it('carries no label, matching the unlabelled cross-connect', () => {
+    const planned = planUserEdge(router('a', 0), router('b', 50));
+    expect(planned!.edge.data?.label).toBeUndefined();
+  });
+
+  it('is lateral, so the path traversal cannot inherit its cosmetic direction', () => {
+    const planned = planUserEdge(router('a', 0), router('b', 50));
+    expect(planned!.edge.data?.isLateral).toBe(true);
+  });
+
+  it('gives the same id whichever way it is drawn, so a redraw de-duplicates', () => {
+    const forward = planUserEdge(router('onprem-EqDC2', 100), router('onprem-EqSE2', 400));
+    const reverse = planUserEdge(router('onprem-EqSE2', 400), router('onprem-EqDC2', 100));
+    expect(forward!.edge.id).toBe(reverse!.edge.id);
+    expect(forward!.edge.id).toBe(customerLinkId('onprem-EqSE2', 'onprem-EqDC2'));
+  });
+
+  it('does not collide with a cross-connect id', () => {
+    const link = planUserEdge(router('onprem-a', 0), router('onprem-b', 50))!;
+    const cross = planUserEdge(router('onprem-a', 0), partner('onprem-b'))!;
+    expect(link.edge.id).not.toBe(cross.edge.id);
+  });
+
+  it('links two routers inside the same site as readily as two sites', () => {
+    // Same customer site: an HA pair, ids sharing the site suffix.
+    const planned = planUserEdge(router('onprem-EqDC2', 100), router('user-onprem-EqDC2-1', 200));
+    expect(planned!.kind).toBe('customerLink');
+  });
+});
+
+describe('planUserEdge — customer link (Customer Gateway ↔ Customer Gateway)', () => {
+  it('links two DX-location customer devices', () => {
+    const planned = planUserEdge(partner('partner-dxcon-a', 100), partner('partner-dxcon-b', 300));
+    expect(planned).not.toBeNull();
+    expect(planned!.kind).toBe('customerLink');
+  });
+
+  it('anchors and labels them exactly like a router pair', () => {
+    const planned = planUserEdge(partner('partner-dxcon-b', 300), partner('partner-dxcon-a', 100));
+    expect(planned!.edge).toMatchObject({
+      id: customerLinkId('partner-dxcon-a', 'partner-dxcon-b'),
+      source: 'partner-dxcon-a',
+      target: 'partner-dxcon-b',
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+      data: { isPeering: true, isLateral: true },
+    });
+  });
+
+  it('does not link a device to a router — that pair is the cross-connect', () => {
+    const planned = planUserEdge(router('onprem-EqDC2', 0), partner('partner-dxcon-a', 200));
+    expect(planned!.kind).toBe('crossConnect');
+  });
+
+  it('leaves the collapsed group card alone', () => {
+    const group = (id: string, y: number): ConnectEndpoint => ({ id, category: 'dxPartnerDeviceGroup', y });
+    expect(planUserEdge(group('g1', 0), group('g2', 100))).toBeNull();
+    expect(planUserEdge(partner('partner-dxcon-a', 0), group('g2', 100))).toBeNull();
+  });
+});
+
+describe('normalizeUserEdges', () => {
+  it('adds the flags back to a link persisted by an older build', () => {
+    const stale = {
+      id: customerLinkId('onprem-a', 'onprem-b'),
+      source: 'onprem-a',
+      target: 'onprem-b',
+      sourceHandle: 'bottom',
+      targetHandle: 'top',
+      data: { isPeering: true },
+    };
+    const [fixed] = normalizeUserEdges([stale]);
+    expect(fixed.data).toMatchObject({ isPeering: true, isLateral: true });
+    // Endpoints and routing are untouched — only the flags are restated.
+    expect(fixed).toMatchObject({ source: 'onprem-a', target: 'onprem-b', sourceHandle: 'bottom' });
+  });
+
+  it('strips the label a build that still drew one left behind', () => {
+    const [fixed] = normalizeUserEdges([
+      {
+        id: customerLinkId('a', 'b'),
+        source: 'a',
+        target: 'b',
+        data: { label: 'Customer Link', isPeering: true, isLateral: true },
+      },
+    ]);
+    expect(fixed.data?.label).toBeUndefined();
+  });
+
+  it('leaves cross-connects alone — they are path steps, not lateral', () => {
+    const cross = { id: 'user-onprem-a-partner-b', source: 'onprem-a', target: 'partner-b' };
+    const [same] = normalizeUserEdges([cross]);
+    expect(same.data?.isLateral).toBeUndefined();
+    expect(same).toBe(cross);
+  });
+
+  it('is idempotent, since it runs on every hydration', () => {
+    const once = normalizeUserEdges(
+      [planUserEdge(router('onprem-a', 0), router('onprem-b', 50))!.edge],
+    );
+    expect(normalizeUserEdges(once)).toEqual(once);
+  });
+});
+
+describe('isUserDrawnPair', () => {
+  it('accepts exactly the pairs planUserEdge can create', () => {
+    expect(isUserDrawnPair('onPremise', 'dxPartnerDevice')).toBe(true);
+    expect(isUserDrawnPair('onPremise', 'onPremise')).toBe(true);
+    expect(isUserDrawnPair('dxPartnerDevice', 'dxPartnerDevice')).toBe(true);
+  });
+
+  it('rejects AWS-reported edges, so they never offer a delete affordance', () => {
+    expect(isUserDrawnPair('dxPartnerDevice', 'awsDevice')).toBe(false);
+    expect(isUserDrawnPair('awsDevice', 'dxGateway')).toBe(false);
+    expect(isUserDrawnPair('dxGateway', 'tgw')).toBe(false);
+    expect(isUserDrawnPair('vpc', 'vpc')).toBe(false);
+  });
+
+  it('rejects an unknown category, since an unresolved node is not a licence to delete', () => {
+    expect(isUserDrawnPair(undefined, 'onPremise')).toBe(false);
+    expect(isUserDrawnPair('onPremise', undefined)).toBe(false);
+  });
+});
+
+describe('planUserEdge — rejections', () => {
+  it('rejects a self-loop', () => {
+    expect(planUserEdge(router('onprem-EqDC2', 100), router('onprem-EqDC2', 100))).toBeNull();
+  });
+
+  it('rejects a missing endpoint', () => {
+    expect(planUserEdge(undefined, router('onprem-a', 0))).toBeNull();
+    expect(planUserEdge(router('onprem-a', 0), undefined)).toBeNull();
+  });
+
+  it('rejects the reverse cross-connect (partner device → router)', () => {
+    expect(planUserEdge(partner('partner-dxcon-a'), router('onprem-EqDC2', 100))).toBeNull();
+  });
+
+  it('rejects every other category pair', () => {
+    const cases: [string, string][] = [
+      ['dxGateway', 'dxGateway'],
+      ['vpc', 'vpc'],
+      ['onPremise', 'dxGateway'],
+      ['onPremise', 'cgw'],
+      ['awsDevice', 'dxPartnerDevice'],
+      ['customerSite', 'onPremise'],
+    ];
+    for (const [srcCat, tgtCat] of cases) {
+      const planned = planUserEdge(
+        { id: 'src', category: srcCat, y: 0 },
+        { id: 'tgt', category: tgtCat, y: 100 },
+      );
+      expect(planned, `${srcCat} → ${tgtCat} must be rejected`).toBeNull();
+    }
+  });
+});

--- a/dx-visualizer/src/utils/user-edges.ts
+++ b/dx-visualizer/src/utils/user-edges.ts
@@ -1,0 +1,174 @@
+import type { DxEdge } from '../types/topology';
+
+/**
+ * The edge kinds a user is allowed to draw on the canvas. Both describe
+ * customer-side cabling that no AWS API reports, which is exactly why they are
+ * hand-drawn rather than discovered:
+ *
+ * `crossConnect` — customer router → DX partner device. The cross-connect
+ *   inside the colo cage.
+ * `customerLink` — a link between two customer-owned devices of the SAME kind:
+ *   router ↔ router in the customer sites, or Customer Gateway ↔ Customer
+ *   Gateway in the DX locations. Either an HA pair in one place, or a link
+ *   between two of them. Without it a reader cannot tell devices that back each
+ *   other up from single points of failure sitting side by side.
+ */
+export type UserEdgeKind = 'crossConnect' | 'customerLink';
+
+/**
+ * Node categories whose members may be linked to one another. Both are customer
+ * hardware — the on-prem router (`onPremise`, shown as "Customer Router") and
+ * the customer's device in the colo (`dxPartnerDevice`, shown as "Customer
+ * Gateway") — and AWS reports the cabling between neither, which is why the
+ * links are drawn rather than discovered.
+ *
+ * A link needs both ends in the SAME category. A router paired with a colo
+ * device is the cross-connect above, not a peer link, and it is matched first.
+ */
+const LINKABLE_PEER_CATEGORIES = new Set(['onPremise', 'dxPartnerDevice']);
+
+/**
+ * One endpoint of an attempted connection. `y` is the node's absolute canvas
+ * position and is needed only to decide which end of a customer link becomes
+ * the source.
+ */
+export interface ConnectEndpoint {
+  id: string;
+  category: string;
+  y: number;
+}
+
+export interface PlannedUserEdge {
+  kind: UserEdgeKind;
+  edge: DxEdge;
+}
+
+/**
+ * The `data` payload every customer link carries, in one place so a link built
+ * fresh and a link restored from storage cannot end up with different flags.
+ *
+ * Deliberately unlabelled, matching the cross-connect: the line between two
+ * cards of the same kind says what it is, and a label box would only crowd a
+ * column that is already tight. `isPeering` still gives it point-to-point hover
+ * from the edge body, which is where the gesture lands with no label to hit.
+ */
+const CUSTOMER_LINK_DATA = { isPeering: true, isLateral: true } as const;
+
+/**
+ * Id for a customer link, deliberately independent of the drag direction: A→B
+ * and B→A are the same piece of cable. `addUserEdge` de-duplicates by id, so a
+ * redraw the other way round is a no-op instead of a second edge stacked on the
+ * first.
+ */
+const CUSTOMER_LINK_ID_PREFIX = 'user-link-';
+
+export function customerLinkId(a: string, b: string): string {
+  const [lo, hi] = [a, b].sort();
+  return `${CUSTOMER_LINK_ID_PREFIX}${lo}--${hi}`;
+}
+
+/**
+ * Restate the customer-link `data` on edges restored from localStorage or from a
+ * snapshot file. Both persist whatever the app wrote at the time, so a link
+ * drawn by an older build comes back with that build's payload: missing
+ * `isLateral`, which decides whether the end-to-end highlight covers the link,
+ * and carrying the "Customer Link" label that has since been dropped. Neither
+ * would correct itself until the user redrew the link.
+ *
+ * Identified by id, which is generated and unique to customer links.
+ */
+export function normalizeUserEdges(edges: DxEdge[]): DxEdge[] {
+  return edges.map((e) => {
+    if (!e.id.startsWith(CUSTOMER_LINK_ID_PREFIX)) return e;
+    const data = { ...e.data, ...CUSTOMER_LINK_DATA };
+    delete data.label;
+    return { ...e, data };
+  });
+}
+
+/**
+ * Decide whether the connection the user just dragged is allowed, and if so
+ * what edge it becomes. Returns null for everything else — the gesture is then
+ * discarded and the canvas is left unchanged.
+ *
+ * Pure, so the rules can be tested without mounting FlowCanvas.
+ */
+export function planUserEdge(
+  src: ConnectEndpoint | undefined,
+  tgt: ConnectEndpoint | undefined,
+  handles: { sourceHandle?: string | null; targetHandle?: string | null } = {},
+): PlannedUserEdge | null {
+  if (!src || !tgt) return null;
+  // React Flow hands over a self-loop if the drag ends back on the node it
+  // started from.
+  if (src.id === tgt.id) return null;
+
+  if (src.category === 'onPremise' && tgt.category === 'dxPartnerDevice') {
+    return {
+      kind: 'crossConnect',
+      edge: {
+        id: `user-${src.id}-${tgt.id}`,
+        source: src.id,
+        target: tgt.id,
+        sourceHandle: handles.sourceHandle ?? undefined,
+        targetHandle: handles.targetHandle ?? undefined,
+        type: 'customEdge',
+      },
+    };
+  }
+
+  if (src.category === tgt.category && LINKABLE_PEER_CATEGORIES.has(src.category)) {
+    return { kind: 'customerLink', edge: makeCustomerLink(src, tgt) };
+  }
+
+  return null;
+}
+
+/**
+ * Whether an edge joining these two categories is one the user drew by hand.
+ * Answered by running the connect rules themselves, so the set of edges that
+ * offer a delete affordance can never drift from the set that can be created —
+ * and nothing else in the app can remove one, so that affordance is the only way
+ * back.
+ */
+export function isUserDrawnPair(
+  sourceCategory: string | undefined,
+  targetCategory: string | undefined,
+): boolean {
+  if (!sourceCategory || !targetCategory) return false;
+  return planUserEdge(
+    { id: 'src', category: sourceCategory, y: 0 },
+    { id: 'tgt', category: targetCategory, y: 1 },
+  ) !== null;
+}
+
+/**
+ * Customer links always route bottom → top, overriding whichever handles the
+ * user happened to grab. Customer routers all share one column, so the two ends
+ * are stacked vertically; a right→left edge between them loops backwards around
+ * both cards and reads as a routing bug rather than a link. Anchoring the upper
+ * node as the source drops the line straight down instead.
+ *
+ * The direction is cosmetic — the cable is bidirectional — so an exact tie on y
+ * breaks on id, keeping the result stable whichever way the user dragged.
+ */
+function makeCustomerLink(a: ConnectEndpoint, b: ConnectEndpoint): DxEdge {
+  const aIsUpper = a.y !== b.y ? a.y < b.y : a.id < b.id;
+  const [from, to] = aIsUpper ? [a, b] : [b, a];
+  return {
+    id: customerLinkId(a.id, b.id),
+    source: from.id,
+    target: to.id,
+    sourceHandle: 'bottom',
+    targetHandle: 'top',
+    type: 'customEdge',
+    // `isPeering` — point-to-point, like a VPC↔VPC or TGW↔TGW peering: hovering
+    // it highlights the two devices it joins rather than running a full
+    // end-to-end BFS through both of their paths.
+    // `isLateral` — and it is not a step along anyone's path either, so the
+    // end-to-end traversal must not walk *through* it. Without this the
+    // highlight inherited the direction chosen above, which is cosmetic: the
+    // link showed up when clicking one side of it and vanished from the other.
+    data: { ...CUSTOMER_LINK_DATA },
+  };
+}


### PR DESCRIPTION
 ## What changed

  You can now draw a line between two of your own devices to say "these two are
  connected." It's called a **Customer Link**.

  - Works between two Customer Routers (in a customer site), or between two
    Customer Gateways (in a DX location)
  - Both ends have to be the *same* kind of device. Linking a router to a colo
    device is the existing cross-connect, not this
  - Drag from the handle on the top or bottom of a card — either direction works,
    the line always ends up drawn the same way
  - Drawing the same link twice does nothing, instead of stacking two lines on
    top of each other
  - The line has no label, same as the cross-connect. Hover it to highlight just
    that pair
  - Remove it by hovering for the `×`, or clicking it and pressing Delete

  ## Notes

  - New module `dx-visualizer/src/utils/user-edges.ts` holds the rules for what
    may be linked to what
  - Two new test files cover the link rules and the hover highlighting
  - `VISUALIZATION.md` documents it, and adds a table clearing up a genuinely
    confusing naming overlap: what the docs call a "Customer Gateway" prints
    **Customer Router** on the card, and what the docs call a "Partner / Customer
    Device" prints **Customer Gateway**
  - Drawn links are stored in the browser and are wiped on a topology refresh or
    scenario switch, because node IDs change between fetches